### PR TITLE
Add test-data to the path for failsafe tests.

### DIFF
--- a/development/test/setup.xml
+++ b/development/test/setup.xml
@@ -19,7 +19,7 @@ Subdirectories that will be created by ERDDAP are:
 The ERDDAP log file (log.txt) will be put in this directory.
 At ERD, we use '/u00/cwatch/erddap/' for releases.
 -->
-<bigParentDirectory>data</bigParentDirectory>
+<bigParentDirectory>target/data</bigParentDirectory>
 
 <!-- baseUrl is the start of the public url, to which "/erddap" 
 is appended. For example:

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <mkdir dir="${project.basedir}/data"/>
+                                <mkdir dir="${project.basedir}/target/data"/>
                             </target>
                         </configuration>
                     </execution>
@@ -376,6 +376,9 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
+                            </additionalClasspathElements>
                             <groups>Jetty, Slow</groups>
                             <excludedGroups>LargeFiles, Flaky, AWS, LocalERDDAP, Password, Thredds, ExternalERDDAP, MissingFile, ExternalOther, IncompleteTest, RequiresContent, MissingDataset</excludedGroups>
                             <includes>


### PR DESCRIPTION
Move the BPD for the test setup to under target so that it is cleared when running mvn clean.

# Description

This makes it so `mvn verify` can successfully run with the changes to how test data is stored.


## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X ] I have performed a self-review of my code
- [X ] My code follows the style guidelines of this project
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
- [X ] New and existing unit tests pass locally with my changes
